### PR TITLE
Fix handling validation errors from workflow dispatch

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -194,7 +194,7 @@ async function run(): Promise<void> {
     const message: string = error.message
     // Handle validation errors from workflow dispatch
     if (
-      message == 'Unexpected inputs provided' ||
+      message.startsWith('Unexpected inputs provided') ||
       (message.startsWith('Required input') &&
         message.endsWith('not provided')) ||
       message.startsWith('No ref found for:') ||


### PR DESCRIPTION
When using unknown workflow dispatch with unknown argument, e.g. `/deploy test=4`,
the error message is now: `Unexpected inputs provided: ["test"]`.

This PR fixes it, because not the action fails and nothing is set as output.