### PR TITLE
Support Bot as an actor

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,12 @@ inputs:
   issue-type:
     description: 'The issue type required for commands.'
     default: both
+  allow-bots:
+    description: 'a comma or newline separated list of bots that are allowed to trigger command dispatches.'
+    default: ''
   allow-edits:
     description: 'Allow edited comments to trigger command dispatches.'
-    default: false
+    default: 'false'
   repository:
     description: 'The full name of the repository to send the dispatch events.'
     default: ${{ github.repository }}

--- a/src/command-helper.ts
+++ b/src/command-helper.ts
@@ -18,6 +18,7 @@ export interface Inputs {
   commands: string[]
   permission: string
   issueType: string
+  allowBots: string[]
   allowEdits: boolean
   repository: string
   eventTypeSuffix: string
@@ -31,6 +32,7 @@ export interface Command {
   command: string
   permission: string
   issue_type: string
+  allow_bots: string[]
   allow_edits: boolean
   repository: string
   event_type_suffix: string
@@ -55,6 +57,7 @@ export interface SlashCommandPayload {
 export const commandDefaults = Object.freeze({
   permission: 'write',
   issue_type: 'both',
+  allow_bots: [],
   allow_edits: false,
   repository: process.env.GITHUB_REPOSITORY || '',
   event_type_suffix: '-command',
@@ -81,6 +84,7 @@ export function getInputs(): Inputs {
     commands: utils.getInputAsArray('commands'),
     permission: core.getInput('permission'),
     issueType: core.getInput('issue-type'),
+    allowBots: utils.getInputAsArray('allow-bots'),
     allowEdits: core.getInput('allow-edits') === 'true',
     repository: core.getInput('repository'),
     eventTypeSuffix: core.getInput('event-type-suffix'),
@@ -117,6 +121,7 @@ export function getCommandsConfigFromInputs(inputs: Inputs): Command[] {
       command: c,
       permission: inputs.permission,
       issue_type: inputs.issueType,
+      allow_bots: inputs.allowBots,
       allow_edits: inputs.allowEdits,
       repository: inputs.repository,
       event_type_suffix: inputs.eventTypeSuffix,
@@ -138,6 +143,7 @@ export function getCommandsConfigFromJson(json: string): Command[] {
       command: jc.command,
       permission: jc.permission ? jc.permission : commandDefaults.permission,
       issue_type: jc.issue_type ? jc.issue_type : commandDefaults.issue_type,
+      allow_bots: jc.allow_bots ? jc.allow_bots : commandDefaults.allow_bots,
       allow_edits: toBool(jc.allow_edits, commandDefaults.allow_edits),
       repository: jc.repository ? jc.repository : commandDefaults.repository,
       event_type_suffix: jc.event_type_suffix
@@ -175,6 +181,19 @@ export function configIsValid(config: Command[]): boolean {
       )
       return false
     }
+    if (command.allow_bots !== undefined ) {
+      if (!Array.isArray(command.allow_bots)) {
+        core.setFailed(`'allow_bots' must be an array`)
+        return false 
+      }
+      
+      const invalidBotNames = command.allow_bots.filter((name) => !name.endsWith('[bot]'))
+      if (invalidBotNames.length > 0) {
+        core.setFailed(`${invalidBotNames.map((name) => `'${name}'`).join(', ')} are not the valid bot names.` )
+        return false
+      }
+    }
+
   }
   return true
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,8 @@ async function run(): Promise<void> {
       github.context.actor
     )
     core.debug(`Actor permission: ${actorPermission}`)
-
+    
+    core.debug(`Try to check bot actor: ${inspect(github.context)}`)
     // Filter matching commands by the user's permission level
     configMatches = configMatches.filter(function (cmd) {
       return actorHasPermission(actorPermission, cmd.permission)

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,24 +121,39 @@ async function run(): Promise<void> {
         'eyes'
       )
 
-    // Get the actor permission
-    const actorPermission = await githubHelper.getActorPermission(
-      github.context.repo,
-      github.context.actor
-    )
-    core.debug(`Actor permission: ${actorPermission}`)
-    
-    core.debug(`Try to check bot actor: ${inspect(github.context)}`)
-    // Filter matching commands by the user's permission level
-    configMatches = configMatches.filter(function (cmd) {
-      return actorHasPermission(actorPermission, cmd.permission)
-    })
-    core.debug(`Config matches on 'permission': ${inspect(configMatches)}`)
-    if (configMatches.length == 0) {
-      core.info(
-        `Command '${commandTokens[0]}' is not configured for the user's permission level '${actorPermission}'.`
+    const isBot = github.context.payload.sender?.type === 'Bot'
+
+    if (!isBot) {
+      // Get the actor permission
+      const actorPermission = await githubHelper.getActorPermission(
+        github.context.repo,
+        github.context.actor
       )
-      return
+      core.debug(`Actor permission: ${actorPermission}`)
+
+      // Filter matching commands by the user's permission level
+      configMatches = configMatches.filter(function (cmd) {
+        return actorHasPermission(actorPermission, cmd.permission)
+      })
+      core.debug(`Config matches on 'permission': ${inspect(configMatches)}`)
+      if (configMatches.length == 0) {
+        core.info(
+          `Command '${commandTokens[0]}' is not configured for the user's permission level '${actorPermission}'.`
+        )
+        return
+      }
+    } else {
+      core.debug(`Bot actor: ${github.context.actor}`)
+      configMatches = configMatches.filter(function (cmd) {
+        return cmd.allow_bots.includes(github.context.actor)
+      })
+
+      if (configMatches.length == 0) {
+        core.info(
+          `Command '${commandTokens[0]}' is not configured to allow bot '${github.context.actor}'.`
+        )
+        return
+      }
     }
 
     // Determined that the command should be dispatched


### PR DESCRIPTION
In my use case, I make several commands as building blocks, then I have a cron workflow to trigger the commands in some sequences. In that case, I want to have the comment as a bot to differentiate between comments from contributors and scheduled actions. The bot token is perfect in this case, IMO.

This PR tested in my case.
Just add `allow-bots` input to, of course, allow to dispatch the commands.

As a preventive, the bot name must be ends with `[bot]` as per GitHub action convention
```
with:
  allow-bots: hello[bot]

```