### PR TITLE
[Security] Fix GraphQL query to get a collaborator's permission

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -302,7 +302,7 @@ class GitHubHelper {
             // Returns 'READ', 'TRIAGE', 'WRITE', 'MAINTAIN', 'ADMIN'
             const query = `query CollaboratorPermission($owner: String!, $repo: String!, $collaborator: String) {
       repository(owner:$owner, name:$repo) {
-        collaborators(query: $collaborator) {
+        collaborators(login: $collaborator) {
           edges {
             permission
           }

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -61,7 +61,7 @@ export class GitHubHelper {
     // Returns 'READ', 'TRIAGE', 'WRITE', 'MAINTAIN', 'ADMIN'
     const query = `query CollaboratorPermission($owner: String!, $repo: String!, $collaborator: String) {
       repository(owner:$owner, name:$repo) {
-        collaborators(query: $collaborator) {
+        collaborators(login: $collaborator) {
           edges {
             permission
           }


### PR DESCRIPTION
> I am terribly sorry for opening a public pull request with the fix for this vulnerability. I tried to reach out to you multiple times via X(Twitter), email from https://peterevans.dev/, and LinkedIn but didn't hear back from you. Plus, there is no security policy, so the only option left is opening a pull request.

The action uses the following GraphQL query to get the permissions of a user who triggered the action:

```js
  async getActorPermission(repo: Repository, actor: string): Promise<string> {
    const query = `query CollaboratorPermission($owner: String!, $repo: String!, $collaborator: String) {
      repository(owner:$owner, name:$repo) {
        collaborators(query: $collaborator) {
          edges {
            permission
          }
        }
      }
    }`
```

The problem is that the `$collaborator` variable is passed to the `query` parameter which implements the fuzzy search. In other words, you can use an outside user with a username close to a maintainer username to bypass the permissions validation.

For example, the query above will return the `ADMIN` permission with the following variables:

- `owner`: `peter-evans`
- `name`: `slash-command-dispatch`
- `collaborator`: `eter-evans` (note there is no the first letter `p`)

So, it means that an attacker can find users with required permissions in a target repository, create a user with a close name (like `eter-evans`), and bypass the permissions validation using that user.

To avoid this behaviour, the `login` parameter must be used instead of `query`.