### PR TITLE
Use nodejs 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ outputs:
   error-message:
     description: 'Validation errors when using `workflow` dispatch.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'target'  


### PR DESCRIPTION
Node 16 has reached its end of life

More details here: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/