### PR TITLE
feat: support yml or yaml

### DIFF
--- a/.github/workflows/hello-yaml-command.yaml
+++ b/.github/workflows/hello-yaml-command.yaml
@@ -1,0 +1,30 @@
+name: Hello yaml Command
+on:
+  repository_dispatch:
+    types: [hello-yaml-local-command]
+jobs:
+  helloYaml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray
+
+      - name: Create URL to the run output
+        id: vars
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          body: |
+            Hello @${{ github.event.client_payload.github.actor }}!
+
+            This command was in a workflow file with the `.yaml` extension.
+
+            [Click here to see the command run output][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           commands: |
+            hello-yaml-local
             hello-world-local
             ping-local
           permission: none

--- a/docs/workflow-dispatch.md
+++ b/docs/workflow-dispatch.md
@@ -19,7 +19,7 @@ There are significant differences in the action's behaviour when using `workflow
 
 It is important to name the `workflow_dispatch` event workflow correctly since the action targets the workflow based on its filename.
 The target filename is a combination of the command name and the `event-type-suffix`.
-Additionally, the file extension must be `.yml`.
+The file extensions `.yml` and `.yaml` are supported.
 
 For the following example configuration, the target workflows are:
 - `deploy-command.yml`


### PR DESCRIPTION
This PR adds support for workflows in yaml or yml by checking which exists by name in `getWorkflow` rather than just setting it to yml.

Here's an example of it working on my fork: https://github.com/patrickleet/slash-command-dispatch/issues/1